### PR TITLE
Draft: feat: overwrite node when pasting

### DIFF
--- a/web/utils/node-data.ts
+++ b/web/utils/node-data.ts
@@ -1,0 +1,8 @@
+import produce from 'immer'
+
+export const dataWithoutPrivateFields = produce((draft: { [key: string]: any }) => {
+  Object.keys(draft).forEach((key) => {
+    if (key.startsWith('_'))
+      delete draft[key]
+  })
+})


### PR DESCRIPTION
This change should allow pasting a node onto another node to overwrite its content. Useful if you want to reuse settings from one node in another.